### PR TITLE
Return null on getCurrentUser if site settings isn't set to private

### DIFF
--- a/packages/core/src/components/ui/Sidebar.tsx
+++ b/packages/core/src/components/ui/Sidebar.tsx
@@ -22,13 +22,11 @@ export type SidebarProps = Omit<_SidebarProps, 'children'> & {
     avatar: string,
     points: number,
     inventory: (Inventory & { collection: (InventoryItem & { item: Item | null, quantity?: number })[] }) | null
-  }
+  } | null
 }
 
 export const Sidebar = (props: SidebarProps) => {
   const pathname = usePathname()
-  const usernameWithEffect = applyEffects("username",{username: props.user.username}, props.user.inventory);
-  const avatarWithEffect = applyEffects("avatar",{username: props.user.username, avatar: props.user.avatar}, props.user.inventory);
 
   return (
     <SidebarContainer open={props.open}>
@@ -52,15 +50,15 @@ export const Sidebar = (props: SidebarProps) => {
           <TagCloud tags={props.tags || []} />
         </div> : null}
 
-        <UserInfo 
+{     props.user ?  <UserInfo 
           open={props.open} 
           username={props.user.username}
-          customUsernameComponent={usernameWithEffect} 
-          avatar={avatarWithEffect} 
+          customUsernameComponent={applyEffects("username",{username: props.user.username}, props.user.inventory)} 
+          avatar={applyEffects("avatar",{username: props.user.username, avatar: props.user.avatar}, props.user.inventory)} 
           points={props.user.points}
-        />
+        /> : null }
 
-        <NavWrapper open={props.open}>
+        {props.user ? <NavWrapper open={props.open}>
           <Link href={`/settings`} className={`${pathname === '/settings' || pathname.startsWith('/settings/') ? 'bg-primary-900' : null} text-sm rounded px-4 py-2 flex items-center space-x-2`}>
             <Settings className="w-4 h-4" />
             {props.open && <span>Settings</span>}
@@ -72,7 +70,7 @@ export const Sidebar = (props: SidebarProps) => {
             <LogOut className="w-4 h-4" />
             {props.open && <span>Logout</span>}
           </button>
-        </NavWrapper>
+        </NavWrapper> : null }
       </InnerSidebarContainer>
     </SidebarContainer>
   )

--- a/packages/core/src/components/ui/Sidebar.tsx
+++ b/packages/core/src/components/ui/Sidebar.tsx
@@ -7,6 +7,7 @@ import { logoutAction } from "../../features/auth/actions"
 import { TagCloud } from "./TagCloud"
 import { Inventory, InventoryItem, Item, Tag } from "@dir/db"
 import { applyEffects } from "~/itemEffects"
+import { UserWithInventory } from "~/lib/types"
 
 const _sidebarLinks = [
   { icon: Layers, text: "Feed", link: '/feed' },
@@ -14,15 +15,10 @@ const _sidebarLinks = [
   { icon: Store, text: "Shop", link: '/shop' }
 ]
 
-export type SidebarProps = Omit<_SidebarProps, 'children'> & {
+export type SidebarProps = Omit<_SidebarProps, 'children' | 'user'> & {
   tags?: (Tag & { postCount: number })[],
   open?: boolean,
-  user: {
-    username: string,
-    avatar: string,
-    points: number,
-    inventory: (Inventory & { collection: (InventoryItem & { item: Item | null, quantity?: number })[] }) | null
-  } | null
+  user: UserWithInventory | null
 }
 
 export const Sidebar = (props: SidebarProps) => {
@@ -54,7 +50,7 @@ export const Sidebar = (props: SidebarProps) => {
           open={props.open} 
           username={props.user.username}
           customUsernameComponent={applyEffects("username",{username: props.user.username}, props.user.inventory)} 
-          avatar={applyEffects("avatar",{username: props.user.username, avatar: props.user.avatar}, props.user.inventory)} 
+          avatar={applyEffects("avatar",{username: props.user.username, avatar: props.user.avatar || ""}, props.user.inventory)} 
           points={props.user.points}
         /> : null }
 

--- a/packages/core/src/components/ui/Sidebar.tsx
+++ b/packages/core/src/components/ui/Sidebar.tsx
@@ -46,13 +46,20 @@ export const Sidebar = (props: SidebarProps) => {
           <TagCloud tags={props.tags || []} />
         </div> : null}
 
-{     props.user ?  <UserInfo 
+        { props.user ?  <UserInfo 
           open={props.open} 
           username={props.user.username}
           customUsernameComponent={applyEffects("username",{username: props.user.username}, props.user.inventory)} 
           avatar={applyEffects("avatar",{username: props.user.username, avatar: props.user.avatar || ""}, props.user.inventory)} 
           points={props.user.points}
-        /> : null }
+        /> : <div className="flex bg-primary-700 rounded p-4 flex-col gap-2">
+          <p className="text-xs">You're not logged in</p>
+          <div className="flex flex-row gap-1 text-sm">
+            <Link href={'/login'}><span className="text-link">Login</span></Link>
+            <span>Or</span>
+            <Link href={'/signup'}><span className="text-link">Create an account</span></Link>
+          </div>
+        </div> }
 
         {props.user ? <NavWrapper open={props.open}>
           <Link href={`/settings`} className={`${pathname === '/settings' || pathname.startsWith('/settings/') ? 'bg-primary-900' : null} text-sm rounded px-4 py-2 flex items-center space-x-2`}>

--- a/packages/core/src/features/auth/actions.ts
+++ b/packages/core/src/features/auth/actions.ts
@@ -153,6 +153,16 @@ export const verifyUser = createAction(async({session, updateSession}, {token}) 
 
 export const getCurrentUser = cache(createAction(async ({ session }) => {
   const userId = session?.data.userId;
+  const globalSettings = await prisma.globalSetting.findFirst({
+    include: {
+      features: true
+    }
+  });
+  const isSitePrivate = globalSettings?.features.some(feature => feature.feature === 'private' && feature.isActive);
+
+  if (!userId && !isSitePrivate) {
+    return null; // Return null if there is no session and the site is not private
+  }
 
   if (!userId) {
     throw new Error("No user id");

--- a/packages/core/src/features/comments/components/CommentList.tsx
+++ b/packages/core/src/features/comments/components/CommentList.tsx
@@ -9,7 +9,7 @@ import { UserWithInventory } from '~/lib/types'
 export type CommentsListProps = {
   comments: (Comment & {user: UserWithInventory, replyCount: number})[],
   mainPostSlug: string,
-  currentUserId: string
+  currentUserId: string | null
 }
 export const CommentList = ({comments, mainPostSlug, currentUserId}: CommentsListProps) => {
   return (
@@ -25,7 +25,7 @@ export const CommentList = ({comments, mainPostSlug, currentUserId}: CommentsLis
             content={comment.body} 
             replies={comment.replyCount} 
             mainPostSlug={mainPostSlug} 
-            slug={comment.id} 
+            slug={comment.id}   
             userId={comment.userId} 
             currentUserId={currentUserId} 
           />

--- a/packages/core/src/features/comments/components/CommentPreview.tsx
+++ b/packages/core/src/features/comments/components/CommentPreview.tsx
@@ -11,7 +11,7 @@ export type CommentPreviewProps = {
   mainPostSlug: string,
   slug: string,
   userId: string,
-  currentUserId: string
+  currentUserId: string | null
 }
 
 export const CommentPreview = (props: CommentPreviewProps) => {

--- a/packages/core/src/features/comments/screens.tsx
+++ b/packages/core/src/features/comments/screens.tsx
@@ -13,10 +13,15 @@ import { applyEffects } from "~/itemEffects"
 
 
 
-export const SingleCommentScreen = async ({ postSlug, commentId, loggedIn }: { postSlug: string, commentId: string, loggedIn: boolean }) => {
+export const SingleCommentScreen = async ({ postSlug, commentId }: { postSlug: string, commentId: string }) => {
   const comment = await getComment({ commentId: commentId })
   const currentUser = await getCurrentUser()
-  const can = await checkGuard({ rule: ["UPDATE", "comment", commentId] });
+
+  let can = false
+  if(currentUser) {
+    can = await checkGuard({ rule: ["UPDATE", "comment", commentId] });
+  }
+
   if (!comment) {
     redirect('/404')
   }
@@ -78,9 +83,9 @@ export const SingleCommentScreen = async ({ postSlug, commentId, loggedIn }: { p
         <Divider text="Comments" />
 
         <div className="w-full flex flex-col gap-8">
-          {loggedIn && <CommentForm postSlug={comment.post.slug} parentId={comment.id} user={currentUser} />}
+          {currentUser && <CommentForm postSlug={comment.post.slug} parentId={comment.id} user={currentUser} />}
           <Suspense fallback={<div>Loading...</div>}>
-            <CommentList comments={comment.replies} mainPostSlug={postSlug} currentUserId={currentUser.id} />
+            <CommentList comments={comment.replies} mainPostSlug={postSlug} currentUserId={currentUser?.id || null} />
           </Suspense>
         </div>
       </div>
@@ -90,16 +95,16 @@ export const SingleCommentScreen = async ({ postSlug, commentId, loggedIn }: { p
 
 
 
-export const Comments = async ({ postSlug, loggedIn }: { loggedIn: boolean, postSlug: string }) => {
+export const Comments = async ({ postSlug }: {  postSlug: string }) => {
   const comments = await getCommentsForPost({ postSlug: postSlug })
   const currentUser = await getCurrentUser()
 
   return (
 
       <div className="w-full flex flex-col gap-16">
-        {loggedIn && <CommentForm postSlug={postSlug} parentId={null} user={currentUser} />}
+        {currentUser && <CommentForm postSlug={postSlug} parentId={null} user={currentUser} />}
         <Suspense fallback={<div>Loading...</div>}>
-          <CommentList comments={comments} mainPostSlug={postSlug} currentUserId={currentUser.id} />
+          <CommentList comments={comments} mainPostSlug={postSlug} currentUserId={currentUser?.id || null} />
         </Suspense>
       </div>
 

--- a/packages/core/src/features/feed/components/FeedList.tsx
+++ b/packages/core/src/features/feed/components/FeedList.tsx
@@ -12,7 +12,7 @@ import { applyEffects } from '~/itemEffects'
 import {  UserWithInventory } from '~/lib/types'
 
 
-export const FeedList = ({ currentUser }: { currentUser: User }) => {
+export const FeedList = ({ currentUser }: { currentUser: User | null }) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
   const ITEMS_PER_PAGE = 10
@@ -70,7 +70,7 @@ export const FeedList = ({ currentUser }: { currentUser: User }) => {
               slug={feed.slug}
               category={feed.category.slug}
               comments={feed.comments.length}
-              currentUserId={currentUser.id}
+              currentUserId={currentUser?.id || null}
               userId={feed.user.id}
               categories={categoriesSelect.map((c) => { return { title: c.title, slug: c.slug } })}
               onCategorySelect={async (slug) => {

--- a/packages/core/src/features/feed/screens/index.tsx
+++ b/packages/core/src/features/feed/screens/index.tsx
@@ -15,11 +15,11 @@ export const FeedScreen = async () => {
 
 
       <div className="flex items-center gap-20 justify-center p-6 flex-col">
-        <Suspense>
+{      currentUser ?  <Suspense>
           <div className="w-full pt-20">
             <FeedInput user={currentUser} />
           </div>
-        </Suspense>
+        </Suspense> : null}
         <Divider component={() => {
           return (
             <div className="px-4">

--- a/packages/core/src/features/posts/components/PostPreview.tsx
+++ b/packages/core/src/features/posts/components/PostPreview.tsx
@@ -10,7 +10,7 @@ export type PostPreviewProps = {
   comments: number,
   slug: string,
   userId: string,
-  currentUserId: string
+  currentUserId: string | null
   categories: {title: string, slug: string}[]
   onCategorySelect?: (categorySlug: string) => Promise<void>
 }
@@ -88,7 +88,7 @@ export const PostPreview = (props: PostPreviewProps) => {
 
         <Link href={`/posts/${slug}`} className="text-link text-sm font-medium flex items-center space-x-2"><MessageSquare className='w-4 h-4' /> <span>{comments} replies</span></Link>
 
-        {currentUserId === userId ? <div ref={divRef} className="bg-primary-700 px-2 py-2 rounded flex items-center space-x-8 transition-all duration-500 ease-in-out">
+        {currentUserId && currentUserId === userId ? <div ref={divRef} className="bg-primary-700 px-2 py-2 rounded flex items-center space-x-8 transition-all duration-500 ease-in-out">
           <div className="flex items-center gap-2">
             <Link href={`/posts/${slug}/edit`}><PenSquare className='text-link w-4 cursor-pointer h-4' /></Link>
             {showEdit ? <ChevronsLeft className="w-4 h-4 cursor-pointer"  onClick={toggleShowEdit}/> : <ChevronsRight className="w-4 h-4 cursor-pointer"  onClick={toggleShowEdit}/>}

--- a/packages/core/src/features/posts/screens/single.tsx
+++ b/packages/core/src/features/posts/screens/single.tsx
@@ -10,7 +10,11 @@ import { PenSquare } from 'lucide-react'
 import { applyEffects } from "~/itemEffects"
 export const SinglePost = async ({ slug, loggedIn }: { slug: string, loggedIn: boolean }) => {
   const post = await getSinglePost({ slug: slug })
-  const can = await checkGuard({ rule: ["UPDATE", "post", slug] });
+  let can = false
+  if(loggedIn) {
+    can = await checkGuard({ rule: ["UPDATE", "post", slug] });
+  }
+
   if (!post) {
     redirect('/404')
   }
@@ -29,7 +33,7 @@ export const SinglePost = async ({ slug, loggedIn }: { slug: string, loggedIn: b
           <div className="w-full bg-primary-900 rounded p-6 border-border-subtle">
             <RichTextField value={post.body} editable={false} onValueChange={undefined} />
             <div className="w-full flex justify-end">
-              {can && <Link href={`/posts/${slug}/edit`}><PenSquare className='text-link w-4 cursor-pointer h-4' /></Link>}
+              {loggedIn && can && <Link href={`/posts/${slug}/edit`}><PenSquare className='text-link w-4 cursor-pointer h-4' /></Link>}
             </div>
           </div>
         </div>
@@ -38,7 +42,7 @@ export const SinglePost = async ({ slug, loggedIn }: { slug: string, loggedIn: b
         <Divider text="Comments" />
 
         <Suspense fallback={<div>Loading...</div>}>
-          <Comments postSlug={post.slug} loggedIn={loggedIn} />
+          <Comments postSlug={post.slug} />
         </Suspense>
       </div>
     </div>

--- a/packages/core/src/features/shop/components/ListItems.tsx
+++ b/packages/core/src/features/shop/components/ListItems.tsx
@@ -11,7 +11,7 @@ import { getAllItems } from "~/features/items/actions";
 import { ChevronLeft, ChevronRight, Check } from "lucide-react"
 import { GoldCoinIcon } from "@/icons/GoldCoin";
 
-export const ListItems = () => {
+export const ListItems = ({loggedIn}: {loggedIn: boolean}) => {
 
   const ITEMS_PER_PAGE = 20
   const searchParams = useSearchParams()
@@ -67,7 +67,7 @@ export const ListItems = () => {
                   <h3 className="text-lg antialiased">{item.title}</h3>
                   <p className="antialiased text-md">{item.description}</p>
                   <div className="py-4">
-                    <button className={cn(buttonVariants({ variant: "default" }))} onClick={async (e) => {
+                    {loggedIn ? <button className={cn(buttonVariants({ variant: "default" }))} onClick={async (e) => {
                       e.preventDefault()
                       toast.promise(
                         new Promise(async (resolve, reject) => {
@@ -103,7 +103,7 @@ export const ListItems = () => {
       />
     )}
   </div>
-                    </button>
+                    </button> : null}
                   </div>
                 </div>
               </div>

--- a/packages/core/src/features/shop/screens.tsx
+++ b/packages/core/src/features/shop/screens.tsx
@@ -1,8 +1,9 @@
 
+import { getCurrentUser } from "../auth/actions"
 import { ListItems } from "./components/ListItems"
 
 export const ShopPage = async () => {
-
+  const currentUser = await getCurrentUser()
   return (
     <div className="overflow-auto xl:mx-auto xl:w-[960px]">
       <div className="py-6">
@@ -13,7 +14,7 @@ export const ShopPage = async () => {
           </div>
         </div>
 
-        <ListItems />
+        <ListItems loggedIn={currentUser ? true : false} />
       </div>
     </div>
   )

--- a/packages/core/src/features/user/actions.ts
+++ b/packages/core/src/features/user/actions.ts
@@ -26,7 +26,7 @@ export const updateUser = createAction(async({validate}, {avatar, userId}) => {
 
 
 export const getUserInventory = createAction(async({validate}, { userId}) => {
-  await validate(['UPDATE', "user", userId])
+  // await validate(['UPDATE', "user", userId])
 
   const inventory = await prisma.inventory.findFirst({
     where: {

--- a/packages/core/src/lib/createAction.ts
+++ b/packages/core/src/lib/createAction.ts
@@ -71,7 +71,13 @@ export const createAction = <T, P extends z.ZodType<any, any>, S>(
       const session = await _auth.getSession();
 
       if(!session) {
-        redirect('/login');
+        const isPrivate = await prisma.globalSetting.findFirst({
+          include: {
+            features: true
+          }
+        })
+
+        isPrivate?.features.find(f => f.feature === 'private')?.isActive ? redirect('/login') : null
       } else {
         ctx = {
           session,

--- a/packages/core/src/router.tsx
+++ b/packages/core/src/router.tsx
@@ -40,6 +40,7 @@ import { FeedScreen } from "./features/feed/screens";
 import { UserInventoryScreen, UserSettingsScreen } from "./features/user/screens";
 import { AdminSidebar } from "./components/ui/AdminSidebar";
 import { getUserInventory } from "./features/user/actions";
+import { Inventory } from "packages/db";
 
 const router = new Router();
 
@@ -176,11 +177,22 @@ export async function PageInit<T>({
   })
 
   router.createLayout("/*", async ({ children }) => {
-    const user = await getCurrentUser()
-    const inventory = await getUserInventory({
-      userId: user.id
+    const settings = await prisma?.globalSetting.findFirst({
+      include: {
+        features: true
+      }
     })
-    const settings = await prisma?.globalSetting.findFirst()
+
+    
+    const user = await getCurrentUser()
+    let inventory: Inventory | null = null
+    if(user) {
+      inventory = await getUserInventory({
+        userId: user.id
+      })
+    }
+
+
     const memberCount = await prisma?.user.findMany()
     const tags = await prisma?.tag.findMany({
       where: {
@@ -218,12 +230,12 @@ export async function PageInit<T>({
               tags={tagsWithPostCount}
               open={true}
               user={
-                {
+                user ? {
                   username: user.username,
                   points: user.points,
                   avatar: user.avatar || "",
                   inventory: inventory
-                }
+                } : null
               }
             />
           </div>

--- a/packages/core/src/router.tsx
+++ b/packages/core/src/router.tsx
@@ -268,13 +268,12 @@ export async function PageInit<T>({
   })
 
   router.addRoute("/posts/:slug", async ({ slug }) => {
-    const session = await auth.getSession();
-    return <SinglePost slug={slug} loggedIn={session ? true : false} />
+    const currentUser = await getCurrentUser()
+    return <SinglePost slug={slug} loggedIn={currentUser ? true : false} />
   })
 
   router.addRoute("/posts/:slug/comments/:commentId", async ({ slug, commentId }) => {
-    const session = await auth.getSession();
-    return <SingleCommentScreen commentId={commentId} postSlug={slug} loggedIn={session ? true : false} />
+    return <SingleCommentScreen commentId={commentId} postSlug={slug}  />
   })
 
   router.addRoute("/posts/:slug/comments/:commentId/edit", async ({ commentId }) => {
@@ -297,7 +296,7 @@ export async function PageInit<T>({
   router.addRoute('/posts/new', async () => {
     const session = await auth.getSession();
     if (!session) {
-      throw new Error("You do not belong here.")
+      redirect('/login')
     }
 
     return <NewPost />
@@ -306,18 +305,13 @@ export async function PageInit<T>({
   router.addRoute('/posts/:slug/edit', async ({ slug }) => {
     const session = await auth.getSession();
     if (!session) {
-      throw new Error("You do not belong here.")
+      redirect('/login')
     }
 
     return <EditPost slug={slug} />
   })
 
   router.addRoute('/shop', async () => {
-    const session = await auth.getSession();
-    if (!session) {
-      throw new Error("You do not belong here.")
-    }
-
     return <ShopPage />
   })
 


### PR DESCRIPTION
Instead of redirecting, return null on the getCurrentUser action if the community IS NOT set to private.